### PR TITLE
🚀 Jacoco Gradle Task 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,6 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'TOTALCOUNT'
-                minimum = 1
                 maximum = 20
             }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,37 +1,88 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.0'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.springframework.boot' version '3.2.0'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'jacoco'
 }
 
 group = 'com.backendoori'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+test {
+    useJUnitPlatform()
+
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    reports {
+        html.required = true
+        xml.required = false
+        csv.required = false
+    }
+
+    finalizedBy jacocoTestCoverageVerification
+    dependsOn test
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.75
+            }
+        }
+
+        rule {
+            element = 'METHOD'
+
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                minimum = 1
+                maximum = 20
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+        }
+    }
+
+    dependsOn jacocoTestReport
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,1 +1,2 @@
+config.stopBubbling = true
 lombok.addLombokGeneratedAnnotation = true

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/test/java/com/backendoori/ootw/OotwApplicationTests.java
+++ b/src/test/java/com/backendoori/ootw/OotwApplicationTests.java
@@ -1,13 +1,26 @@
 package com.backendoori.ootw;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class OotwApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @DisplayName("main 메서드를 실행할 수 있다")
+    @Test
+    void testMain() {
+        // given
+        String[] args = new String[0];
+
+        // when
+        ThrowingCallable main = () -> OotwApplication.main(args);
+
+        // then
+        assertThatNoException().isThrownBy(main);
+    }
 
 }


### PR DESCRIPTION
## ✅ 요구사항 #13
- [x] Jacoco plugin 적용
- [x] Java 코드에 대한 커버리지를 체크

## 🚀 주요 변경사항
- [x] Gradle Task 추가
  - gradle test가 실행될 때 마다 다음의 task가 자동적으로 실행
  - jacocoTestReport
  - jacocoTestCoverageVerification
- [x] Test 커버리지 기준 설정
  - `Class`는 **코드 라인의 75%가 COVER** 되어야 함
  - `Method`는 **코드 라인이 20줄 이내** 여야 함
  - `Method` 내부의 **Branch**(ex. `if`, `switch`)는 **코드 라인의 90%가 COVER** 되어야 함
- [x] Test 커버리지 report 생성

## 💡 기타사항
<!-- ex) 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
- lombok 이슈 해결
  - getter, setter 등 어노테이션으로 추가된 생성자 및 메서드가
  - jacoco 테스트 커버리지에 영향을 주지 않도록 [lombok.config](https://www.baeldung.com/lombok-configuration-system) 파일에 `addLombokGeneratedAnnotation` 설정 추가