### PR TITLE
🚀 게시글 작성 서비스에 이미지 저장 및 url 반환 로직 도입

### DIFF
--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -33,7 +33,7 @@ CREATE TABLE posts
     user_id    BIGINT       NOT NULL,
     title      VARCHAR(30)  NOT NULL,
     content    VARCHAR(255) NOT NULL,
-    image      VARCHAR(255) NULL,
+    image      VARCHAR(500) NULL,
     created_at DATETIME(6)  NULL,
     updated_at DATETIME(6)  NULL,
     current_temperature DOUBLE                                                  NOT NULL,

--- a/src/main/java/com/backendoori/ootw/post/controller/PostController.java
+++ b/src/main/java/com/backendoori/ootw/post/controller/PostController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +21,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/posts")
@@ -30,8 +33,10 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping
-    public ResponseEntity<PostSaveResponse> save(@RequestBody @Valid PostSaveRequest request) {
-        PostSaveResponse response = postService.save(request);
+    public ResponseEntity<PostSaveResponse> save(
+        @RequestPart MultipartFile postImg,
+        @RequestPart @Valid PostSaveRequest request) {
+        PostSaveResponse response = postService.save(request, postImg);
 
         URI postUri = URI.create("/api/v1/posts/" + response.postId());
 
@@ -43,7 +48,7 @@ public class PostController {
     @GetMapping("/{postId}")
     public ResponseEntity<PostReadResponse> readDetailByPostId(@PathVariable Long postId) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(postService.getDatailByPostId(postId));
+            .body(postService.getDetailByPostId(postId));
     }
 
     @GetMapping

--- a/src/main/java/com/backendoori/ootw/post/domain/Post.java
+++ b/src/main/java/com/backendoori/ootw/post/domain/Post.java
@@ -49,18 +49,18 @@ public class Post extends BaseEntity {
     @Embedded
     private Weather weather;
 
-    private Post(User user, PostSaveRequest request) {
+    private Post(User user, PostSaveRequest request, String imgUrl) {
         validateUser(user);
         validatePostSaveRequest(request);
         this.user = user;
         this.title = request.title();
         this.content = request.content();
-        this.image = request.image();
+        this.image = imgUrl;
         this.weather = Weather.from(request.weather());
     }
 
-    public static Post from(User user, PostSaveRequest request) {
-        return new Post(user, request);
+    public static Post from(User user, PostSaveRequest request, String imgUrl) {
+        return new Post(user, request, imgUrl);
     }
 
     // TODO: Validator 클래스를 독립적으로 만드는 것이 나을까..?

--- a/src/main/java/com/backendoori/ootw/post/dto/PostSaveRequest.java
+++ b/src/main/java/com/backendoori/ootw/post/dto/PostSaveRequest.java
@@ -16,8 +16,6 @@ public record PostSaveRequest(
     @Size(max = 500)
     String content,
 
-    String image,
-
     WeatherDto weather
 ) {
 

--- a/src/main/java/com/backendoori/ootw/post/service/PostService.java
+++ b/src/main/java/com/backendoori/ootw/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.backendoori.ootw.post.service;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import com.backendoori.ootw.common.image.ImageService;
 import com.backendoori.ootw.post.domain.Post;
 import com.backendoori.ootw.post.dto.PostReadResponse;
 import com.backendoori.ootw.post.dto.PostSaveRequest;
@@ -12,6 +13,7 @@ import com.backendoori.ootw.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
@@ -19,20 +21,23 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final ImageService imageService;
 
     @Transactional
-    public PostSaveResponse save(PostSaveRequest request) {
+    public PostSaveResponse save(PostSaveRequest request, MultipartFile postImg) {
+
         // TODO: 사용자 인증/인가 로직 추가
         User user = userRepository.findById(request.userId())
             .orElseThrow(() -> new NoSuchElementException("해당하는 유저가 없습니다."));
+        String imgUrl = imageService.uploadImage(postImg);
 
-        Post savedPost = postRepository.save(Post.from(user, request));
+        Post savedPost = postRepository.save(Post.from(user, request, imgUrl));
 
         return PostSaveResponse.from(savedPost);
     }
 
     @Transactional(readOnly = true)
-    public PostReadResponse getDatailByPostId(Long postId) {
+    public PostReadResponse getDetailByPostId(Long postId) {
         Post post = postRepository.findByIdWithUserEntityGraph(postId)
             .orElseThrow(() -> new NoSuchElementException("해당하는 게시글이 없습니다."));
 

--- a/src/test/java/com/backendoori/ootw/avatar/controller/AvatarItemControllerTest.java
+++ b/src/test/java/com/backendoori/ootw/avatar/controller/AvatarItemControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
@@ -30,6 +31,7 @@ class AvatarItemControllerTest {
     ObjectMapper objectMapper;
 
     @Test
+    @WithMockUser
     @DisplayName("아바타 이미지 업로드 api 테스트")
     public void imageUploadTest() throws Exception {
         //given

--- a/src/test/java/com/backendoori/ootw/post/controller/PostControllerTest.java
+++ b/src/test/java/com/backendoori/ootw/post/controller/PostControllerTest.java
@@ -36,7 +36,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
 class PostControllerTest {
 
     User savedUser;

--- a/src/test/java/com/backendoori/ootw/post/controller/PostControllerTest.java
+++ b/src/test/java/com/backendoori/ootw/post/controller/PostControllerTest.java
@@ -2,6 +2,7 @@ package com.backendoori.ootw.post.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -28,10 +29,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class PostControllerTest {
 
     User savedUser;
@@ -68,21 +73,26 @@ class PostControllerTest {
     class Save {
 
         @Test
+        @WithMockUser
         @DisplayName("게시글 저장에 성공한다.")
         void saveSuccess() throws Exception {
             // given
             WeatherDto weatherDto =
                 new WeatherDto(0.0, -10.0, 10.0, 1, 1);
             PostSaveRequest request =
-                new PostSaveRequest(savedUser.getId(), "Test Title", "Test Content", null, weatherDto);
+                new PostSaveRequest(savedUser.getId(), "Test Title", "Test Content", weatherDto);
+            MockMultipartFile postImg = new MockMultipartFile("file", "filename.txt",
+                "text/plain", "some xml".getBytes());
 
             // when, then
-            MockHttpServletResponse response = mockMvc.perform(post("http://localhost:8080/api/v1/posts")
+            MockHttpServletResponse response = mockMvc.perform(multipart("http://localhost:8080/api/v1/posts")
+                    .file(postImg)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                    .content(objectMapper.writeValueAsBytes(request))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsBytes(request)))
+                    .characterEncoding("utf-8"))
                 .andExpect(status().isCreated())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+//                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn()
                 .getResponse();
 
@@ -90,16 +100,21 @@ class PostControllerTest {
         }
 
         @Test
+        @WithMockUser
         @DisplayName("저장되지 않은 유저가 포함된 게시글 저장에 실패한다.")
         void saveFailNonSavedUser() throws Exception {
             // given
             WeatherDto weatherDto =
                 new WeatherDto(0.0, -10.0, 10.0, 1, 1);
             PostSaveRequest request =
-                new PostSaveRequest(savedUser.getId() + 1, "Test Title", "Test Content", null, weatherDto);
+                new PostSaveRequest(savedUser.getId(), "Test Title", "Test Content", weatherDto);
+            MockMultipartFile postImg = new MockMultipartFile("file", "filename.txt",
+                "text/plain", "some xml".getBytes());
 
             // when, then
-            mockMvc.perform(post("http://localhost:8080/api/v1/posts")
+            mockMvc.perform(multipart("http://localhost:8080/api/v1/posts")
+                    .file(postImg)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsBytes(request)))
@@ -108,16 +123,21 @@ class PostControllerTest {
         }
 
         @Test
+        @WithMockUser
         @DisplayName("유효하지 않은 요청 값(게시글 title)이 포함된 게시글 저장에 실패한다.")
         void saveFailByMethodArgumentNotValidException() throws Exception {
             // given
             WeatherDto weatherDto =
                 new WeatherDto(0.0, -10.0, 10.0, 1, 1);
             PostSaveRequest request =
-                new PostSaveRequest(savedUser.getId(), null, "Test Content", null, weatherDto);
+                new PostSaveRequest(savedUser.getId(), "Test Title", "Test Content", weatherDto);
+            MockMultipartFile postImg = new MockMultipartFile("file", "filename.txt",
+                "text/plain", "some xml".getBytes());
 
             // when, then
-            String response = mockMvc.perform(post("http://localhost:8080/api/v1/posts")
+            String response = mockMvc.perform(multipart("http://localhost:8080/api/v1/posts")
+                    .file(postImg)
+                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsBytes(request)))
@@ -133,13 +153,14 @@ class PostControllerTest {
         }
 
         @Test
+        @WithMockUser
         @DisplayName("유효하지 않은 요청 값(현재 기온)이 포함된 게시글 저장에 실패한다.")
         void saveFailInvalidValueByIllegalArgumentException() throws Exception {
             // given
             WeatherDto weatherDto =
                 new WeatherDto(900.0, -10.0, 10.0, 1, 1);
             PostSaveRequest request =
-                new PostSaveRequest(savedUser.getId(), "Test Title", "Test Content", null, weatherDto);
+                new PostSaveRequest(savedUser.getId(), "Test Title", "Test Content", weatherDto);
 
             // when, then
             String response = mockMvc.perform(post("http://localhost:8080/api/v1/posts")
@@ -165,29 +186,34 @@ class PostControllerTest {
         void setUp() {
             WeatherDto weatherDto =
                 new WeatherDto(0.0, -10.0, 10.0, 1, 1);
+            MockMultipartFile postImg = new MockMultipartFile("file", "filename.txt",
+                "text/plain", "some xml".getBytes());
             savedPost = postService.save(
-                new PostSaveRequest(savedUser.getId(), "Test Title", "Test Content", null, weatherDto));
+                new PostSaveRequest(savedUser.getId(), "Test Title", "Test Content", weatherDto), postImg,
+                authentication.getPrincipal());
         }
 
         @Test
-        @DisplayName("게시글 단건 조회에 성공한다.")
-        void getDatailByPostIdSuccess() throws Exception {
-            // given, when, then
-            mockMvc.perform(get("http://localhost:8080/api/v1/posts/" + savedPost.postId())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
-        }
-
-        @Test
+        @WithMockUser
         @DisplayName("존재하지 않는 게시글 단건 조회에 실패한다.")
-        void getDatailByPostIdFailNonSavedPost() throws Exception {
+        void getDetailByPostIdFailNonSavedPost() throws Exception {
             // given, when, then
             mockMvc.perform(get("http://localhost:8080/api/v1/posts/" + savedPost.postId() + 1)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("게시글 단건 조회에 성공한다.")
+        void getDetailByPostIdSuccess() throws Exception {
+            // given, when, then
+            mockMvc.perform(get("http://localhost:8080/api/v1/posts/" + savedPost.postId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         }
 
@@ -205,14 +231,17 @@ class PostControllerTest {
             WeatherDto weatherDto =
                 new WeatherDto(0.0, -10.0, 10.0, 1, 1);
             PostSaveRequest request =
-                new PostSaveRequest(savedUser.getId(), "Test Title", "Test Content", null, weatherDto);
+                new PostSaveRequest(savedUser.getId(), "Test Title", "Test Content", weatherDto);
+            MockMultipartFile postImg = new MockMultipartFile("file", "filename.txt",
+                "text/plain", "some xml".getBytes());
 
             for (int i = 0; i < SAVE_COUNT; i++) {
-                postService.save(request);
+                postService.save(request, postImg, authentication.getPrincipal());
             }
         }
 
         @Test
+        @WithMockUser
         @DisplayName("게시글 목록 조회 성공")
         void getAllSuccess() throws Exception {
             // given, when, then

--- a/src/test/java/com/backendoori/ootw/post/domain/PostTest.java
+++ b/src/test/java/com/backendoori/ootw/post/domain/PostTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.mock.web.MockMultipartFile;
 
 class PostTest {
 
@@ -26,23 +27,23 @@ class PostTest {
     private static Stream<Arguments> provideInvalidInfo() {
         return Stream.of(
             Arguments.of("userId가 null인 경우",
-                new PostSaveRequest(null, "Test Title", "Test Content", null, WEATHER_DTO)),
+                new PostSaveRequest(null, "Test Title", "Test Content", WEATHER_DTO)),
             Arguments.of("title이 null인 경우",
-                new PostSaveRequest(USER_ID, null, "Test Content", null, WEATHER_DTO)),
+                new PostSaveRequest(USER_ID, null, "Test Content", WEATHER_DTO)),
             Arguments.of("title이 공백인 경우",
-                new PostSaveRequest(USER_ID, " ", "Test Content", null, WEATHER_DTO)),
+                new PostSaveRequest(USER_ID, " ", "Test Content", WEATHER_DTO)),
             Arguments.of("title이 30자를 넘는 경우",
-                new PostSaveRequest(USER_ID, "T".repeat(31), "Test Content", null, WEATHER_DTO)),
+                new PostSaveRequest(USER_ID, "T".repeat(31), "Test Content", WEATHER_DTO)),
             Arguments.of("content가 null인 경우",
-                new PostSaveRequest(USER_ID, "Test Title", null, null, WEATHER_DTO)),
+                new PostSaveRequest(USER_ID, "Test Title", null, WEATHER_DTO)),
             Arguments.of("content가 공백인 경우",
-                new PostSaveRequest(USER_ID, "Test Title", " ", null, WEATHER_DTO)),
+                new PostSaveRequest(USER_ID, "Test Title", " ", WEATHER_DTO)),
             Arguments.of("content가 500자를 넘는 경우",
-                new PostSaveRequest(USER_ID, "Test Title", "T".repeat(501), null, WEATHER_DTO)),
+                new PostSaveRequest(USER_ID, "Test Title", "T".repeat(501),  WEATHER_DTO)),
             Arguments.of("weather가 null인 경우",
-                new PostSaveRequest(USER_ID, "Test Title", "Test Content", null, null)),
+                new PostSaveRequest(USER_ID, "Test Title", "Test Content",null)),
             Arguments.of("weather가 유효하지 않은 값인 경우",
-                new PostSaveRequest(USER_ID, "Test Title", "Test Content", null, INVALID_WEATHER_DTO))
+                new PostSaveRequest(USER_ID, "Test Title", "Test Content", INVALID_WEATHER_DTO))
         );
     }
 
@@ -51,17 +52,18 @@ class PostTest {
     void createPostSuccess() {
         // given
         PostSaveRequest request =
-            new PostSaveRequest(USER_ID, "Test Title", "Test Content", null, WEATHER_DTO);
+            new PostSaveRequest(USER_ID, "Test Title", "Test Content", WEATHER_DTO);
+        String imgUrl = "imgUrl";
 
         // when
-        Post createdPost = Post.from(MOCK_USER, request);
+        Post createdPost = Post.from(MOCK_USER, request, imgUrl);
 
         // then
         assertAll(
             () -> assertThat(createdPost).hasFieldOrPropertyWithValue("user", MOCK_USER),
             () -> assertThat(createdPost).hasFieldOrPropertyWithValue("title", request.title()),
             () -> assertThat(createdPost).hasFieldOrPropertyWithValue("content", request.content()),
-            () -> assertThat(createdPost).hasFieldOrPropertyWithValue("image", request.image()),
+            () -> assertThat(createdPost).hasFieldOrPropertyWithValue("image", imgUrl),
             () -> assertThat(createdPost).hasFieldOrPropertyWithValue("weather", Weather.from(WEATHER_DTO))
         );
     }
@@ -71,8 +73,10 @@ class PostTest {
     @DisplayName("from 메서드로 유효하지 않은 User, PostSaveRequest로부터 Post를 생성하는 것에 실패한다.")
     void createPostFail(String info, PostSaveRequest postSaveRequest) {
         // given, when, then
+        String imgUrl = "imgUrl";
+
         assertThrows(IllegalArgumentException.class,
-            () -> Post.from(MOCK_USER, postSaveRequest));
+            () -> Post.from(MOCK_USER, postSaveRequest, imgUrl));
 
         // TODO: 에러 메시지 검증
     }


### PR DESCRIPTION
## ✅ 요구사항 
- [x] 게시글 작성 로직에 실제 이미지 저장 로직 연결

## 🚀 주요 변경사항
- Request 요청을 분리하여 이미지 파일도 스프링에서 함께 받을 수 있게 변경
    - @RequestPart로 넣어 이미지와 기존 요청을 분리
- PostService에 이미지 저장 로직 추가
    - ImageService 를 PostService에 추가하여 로직 사용
    - MinIO에 MultipartFile 로 올라온 이미지 파일 저장 후 이미지 url 반환
    - 반환된 Image와 request 정보, user 정보를 포함하여 Post의 Entity 객체를 생성
        - Post 생성자 로직도 기존 request 정보에 포함된 imageUrl이 아닌 실제 storage 저장 후 반환된 이미지를 사용하도록 변경
    - 생성된 Post 객체를 저장 후 정보를 반환하는 식으로 변경

## 💡 기타사항
- 추후 user Authentication 로직 도입 후 테스트 코드 리팩토링 예정
<details>
<summary> postman을 이용한 게시글 요청 화면</summary>

<img src="https://github.com/backendoori/ootw-backend/assets/85065626/8b51bca9-3884-46eb-b3ac-591be144172b" width=600px>
</br>

request 정보
```json
{
    "userId": 1,
    "title": "title",
    "content": "contents",
    "weather":{
        "currentTemperature":1.0,
        "dayMinTemperature":1.0,
        "dayMaxTemperature":1.0,
        "skyCode":1,
        "ptyCode":1
    }
}

```

</details>

<details>
<summary> 실제 반환받은 이미지 url로 접속 시 브라우저에서 보이는 이미지 화면</summary>

<img src="https://github.com/backendoori/ootw-backend/assets/85065626/fc7e48e6-474a-4abe-8494-2811ae15965d" width=600px>

</details>

<details>
<summary> post 저장 시 db에 저장된 post 정보</summary>

<img src="https://github.com/backendoori/ootw-backend/assets/85065626/dd1c8220-b8f3-4991-aefc-afa8315a7bce" width=600px>

</details>