### PR TITLE
🔨 2차 스프린트 리뷰 반영 - field name, validation, annotation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,18 +31,23 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.0'
-    implementation 'org.apache.commons:commons-lang3'
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+
     implementation "io.minio:minio:8.5.7"
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'org.apache.commons:commons-lang3'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+
     compileOnly 'org.projectlombok:lombok'
+
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+
     testImplementation 'net.datafaker:datafaker:2.0.2'
     testImplementation 'com.icegreen:greenmail-junit5:2.0.1'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 jacoco {

--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -4,14 +4,14 @@ USE ootw;
 
 CREATE TABLE users
 (
-    id         BIGINT AUTO_INCREMENT,
-    email      VARCHAR(255) NOT NULL,
-    password   VARCHAR(255) NOT NULL,
-    nickname   VARCHAR(255) NOT NULL,
-    image      VARCHAR(500) NULL,
-    certified  TINYINT(1)   NOT NULL,
-    created_at DATETIME(6)  NULL,
-    updated_at DATETIME(6)  NULL,
+    id                BIGINT AUTO_INCREMENT,
+    email             VARCHAR(255) NOT NULL,
+    password          VARCHAR(255) NOT NULL,
+    nickname          VARCHAR(255) NOT NULL,
+    profile_image_url VARCHAR(500) NULL,
+    certified         TINYINT(1)   NOT NULL,
+    created_at        DATETIME(6)  NULL,
+    updated_at        DATETIME(6)  NULL,
     CONSTRAINT users_pk
         PRIMARY KEY (id),
     CONSTRAINT users_email_index
@@ -30,16 +30,16 @@ CREATE TABLE avatar_items
 
 CREATE TABLE posts
 (
-    id         BIGINT AUTO_INCREMENT,
-    user_id    BIGINT       NOT NULL,
-    title      VARCHAR(30)  NOT NULL,
-    content    VARCHAR(255) NOT NULL,
-    image      VARCHAR(500) NULL,
-    created_at DATETIME(6)  NULL,
-    updated_at DATETIME(6)  NULL,
-    like_cnt   INTEGER      NULL,
-    min_temperature DOUBLE NOT NULL,
-    max_temperature DOUBLE NOT NULL,
+    id              BIGINT AUTO_INCREMENT,
+    user_id         BIGINT       NOT NULL,
+    title           VARCHAR(30)  NOT NULL,
+    content         VARCHAR(255) NOT NULL,
+    image           VARCHAR(500) NULL,
+    created_at      DATETIME(6)  NULL,
+    updated_at      DATETIME(6)  NULL,
+    like_cnt        INTEGER      NULL,
+    min_temperature DOUBLE       NOT NULL,
+    max_temperature DOUBLE       NOT NULL,
     CONSTRAINT posts_pk
         PRIMARY KEY (id),
     FOREIGN KEY (user_id)
@@ -49,11 +49,11 @@ CREATE TABLE posts
 CREATE TABLE likes
 (
     id         BIGINT AUTO_INCREMENT,
-    user_id    BIGINT       NOT NULL,
-    post_id    BIGINT       NOT NULL,
-    is_like    TINYINT      NOT NULL,
-    created_at DATETIME(6)  NULL,
-    updated_at DATETIME(6)  NULL,
+    user_id    BIGINT      NOT NULL,
+    post_id    BIGINT      NOT NULL,
+    is_like    TINYINT     NOT NULL,
+    created_at DATETIME(6) NULL,
+    updated_at DATETIME(6) NULL,
     CONSTRAINT posts_pk
         PRIMARY KEY (id),
     FOREIGN KEY (user_id)

--- a/src/main/java/com/backendoori/ootw/common/OotwMailSender.java
+++ b/src/main/java/com/backendoori/ootw/common/OotwMailSender.java
@@ -23,7 +23,7 @@ public class OotwMailSender {
         try {
             sendMimeMessage(receiver, title, body);
         } catch (MessagingException e) {
-            log.error("Fail to send email to {}, title: {}, body: {}", receiver, title, body, e);
+            log.error("Fail to send email, receiver: {} title: {}, body: {}", receiver, title, body, e);
         }
     }
 

--- a/src/main/java/com/backendoori/ootw/config/ExceptionHandlerConfigurer.java
+++ b/src/main/java/com/backendoori/ootw/config/ExceptionHandlerConfigurer.java
@@ -3,14 +3,14 @@ package com.backendoori.ootw.config;
 import java.io.IOException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.stereotype.Component;
 
-@Component
+@Configuration
 public class ExceptionHandlerConfigurer implements Customizer<ExceptionHandlingConfigurer<HttpSecurity>> {
 
     @Override

--- a/src/main/java/com/backendoori/ootw/config/HttpRequestsConfigurer.java
+++ b/src/main/java/com/backendoori/ootw/config/HttpRequestsConfigurer.java
@@ -1,11 +1,11 @@
 package com.backendoori.ootw.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
-import org.springframework.stereotype.Component;
 
-@Component
+@Configuration
 public class HttpRequestsConfigurer
     implements Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> {
 

--- a/src/main/java/com/backendoori/ootw/post/dto/WriterDto.java
+++ b/src/main/java/com/backendoori/ootw/post/dto/WriterDto.java
@@ -9,7 +9,7 @@ public record WriterDto(
 ) {
 
     public static WriterDto from(User user) {
-        return new WriterDto(user.getId(), user.getNickname(), user.getImage());
+        return new WriterDto(user.getId(), user.getNickname(), user.getProfileImageUrl());
     }
 
 }

--- a/src/main/java/com/backendoori/ootw/security/jwt/Message.java
+++ b/src/main/java/com/backendoori/ootw/security/jwt/Message.java
@@ -1,0 +1,14 @@
+package com.backendoori.ootw.security.jwt;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class Message {
+
+    public static final String INVALID_SIGNATURE = "Invalid JWT signature.";
+    public static final String EXPIRED_TOKEN = "Expired JWT token.";
+    public static final String UNSUPPORTED_TOKEN = "Unsupported JWT token.";
+    public static final String UNEXPECTED_TOKEN = "JWT token compact of handler are invalid.";
+
+}

--- a/src/main/java/com/backendoori/ootw/security/jwt/TokenProvider.java
+++ b/src/main/java/com/backendoori/ootw/security/jwt/TokenProvider.java
@@ -78,13 +78,13 @@ public class TokenProvider {
 
     private void loggingException(RuntimeException e) {
         if (e instanceof SecurityException || e instanceof MalformedJwtException) {
-            log.debug("Invalid JWT signature.", e);
+            log.debug(Message.INVALID_SIGNATURE, e);
         } else if (e instanceof ExpiredJwtException) {
-            log.debug("Expired JWT token.", e);
+            log.debug(Message.EXPIRED_TOKEN, e);
         } else if (e instanceof UnsupportedJwtException) {
-            log.debug("Unsupported JWT token.", e);
+            log.debug(Message.UNSUPPORTED_TOKEN, e);
         } else {
-            log.debug("JWT token compact of handler are invalid.", e);
+            log.debug(Message.UNEXPECTED_TOKEN, e);
         }
     }
 

--- a/src/main/java/com/backendoori/ootw/user/controller/CertificateController.java
+++ b/src/main/java/com/backendoori/ootw/user/controller/CertificateController.java
@@ -20,7 +20,7 @@ public class CertificateController {
 
     @PatchMapping("/certificate")
     public ResponseEntity<Void> sendCode(@Valid SendCodeDto sendCodeDto) {
-        certificateService.sendCertificate(sendCodeDto);
+        certificateService.sendCode(sendCodeDto);
 
         return ResponseEntity.status(HttpStatus.OK)
             .build();

--- a/src/main/java/com/backendoori/ootw/user/controller/CertificateController.java
+++ b/src/main/java/com/backendoori/ootw/user/controller/CertificateController.java
@@ -1,7 +1,7 @@
 package com.backendoori.ootw.user.controller;
 
 import com.backendoori.ootw.user.dto.CertifyDto;
-import com.backendoori.ootw.user.dto.SendCertificateDto;
+import com.backendoori.ootw.user.dto.SendCodeDto;
 import com.backendoori.ootw.user.service.CertificateService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +19,8 @@ public class CertificateController {
     private final CertificateService certificateService;
 
     @PatchMapping("/certificate")
-    public ResponseEntity<Void> sendCertificate(@Valid SendCertificateDto sendCertificateDto) {
-        certificateService.sendCertificate(sendCertificateDto);
+    public ResponseEntity<Void> sendCode(@Valid SendCodeDto sendCodeDto) {
+        certificateService.sendCertificate(sendCodeDto);
 
         return ResponseEntity.status(HttpStatus.OK)
             .build();

--- a/src/main/java/com/backendoori/ootw/user/domain/User.java
+++ b/src/main/java/com/backendoori/ootw/user/domain/User.java
@@ -43,7 +43,7 @@ public class User extends BaseEntity {
     @Column(name = "certified", nullable = false, columnDefinition = "TINYINT(1)")
     private boolean certified;
 
-    public User(Long id, String email, String password, String nickname, String profileImageUrl, Boolean certified) {
+    public User(Long id, String email, String password, String nickname, String profileImageUrl, boolean certified) {
         AssertUtil.hasPattern(email, RFC5322.REGEX, Message.INVALID_EMAIL);
         AssertUtil.isTrue(email.length() <= 255, Message.TOO_LONG_EMAIL);
         AssertUtil.notBlank(password, Message.BLANK_PASSWORD);

--- a/src/main/java/com/backendoori/ootw/user/domain/User.java
+++ b/src/main/java/com/backendoori/ootw/user/domain/User.java
@@ -37,13 +37,13 @@ public class User extends BaseEntity {
     @Column(name = "nickname", nullable = false)
     private String nickname;
 
-    @Column(name = "image")
-    private String image;
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
 
     @Column(name = "certified", nullable = false, columnDefinition = "TINYINT(1)")
-    private Boolean certified;
+    private boolean certified;
 
-    public User(Long id, String email, String password, String nickname, String image, Boolean certified) {
+    public User(Long id, String email, String password, String nickname, String profileImageUrl, Boolean certified) {
         AssertUtil.hasPattern(email, RFC5322.REGEX, Message.INVALID_EMAIL);
         AssertUtil.isTrue(email.length() <= 255, Message.TOO_LONG_EMAIL);
         AssertUtil.notBlank(password, Message.BLANK_PASSWORD);
@@ -54,7 +54,7 @@ public class User extends BaseEntity {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
-        this.image = image;
+        this.profileImageUrl = profileImageUrl;
         this.certified = certified;
     }
 

--- a/src/main/java/com/backendoori/ootw/user/dto/CertifyDto.java
+++ b/src/main/java/com/backendoori/ootw/user/dto/CertifyDto.java
@@ -4,18 +4,15 @@ import com.backendoori.ootw.user.domain.Certificate;
 import com.backendoori.ootw.user.validation.RFC5322;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record CertifyDto(
-    @NotNull
     @NotBlank
     @Size(max = 255)
     @Email(regexp = RFC5322.REGEX)
     String email,
 
-    @NotNull
     @NotBlank
     @Pattern(regexp = Certificate.REGEX)
     String code

--- a/src/main/java/com/backendoori/ootw/user/dto/LoginDto.java
+++ b/src/main/java/com/backendoori/ootw/user/dto/LoginDto.java
@@ -4,17 +4,14 @@ import com.backendoori.ootw.user.validation.Password;
 import com.backendoori.ootw.user.validation.RFC5322;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record LoginDto(
-    @NotNull
     @NotBlank
     @Size(max = 255)
     @Email(regexp = RFC5322.REGEX)
     String email,
 
-    @NotNull
     @Password
     String password
 ) {

--- a/src/main/java/com/backendoori/ootw/user/dto/SendCodeDto.java
+++ b/src/main/java/com/backendoori/ootw/user/dto/SendCodeDto.java
@@ -3,11 +3,9 @@ package com.backendoori.ootw.user.dto;
 import com.backendoori.ootw.user.validation.RFC5322;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record SendCodeDto(
-    @NotNull
     @NotBlank
     @Size(max = 255)
     @Email(regexp = RFC5322.REGEX)

--- a/src/main/java/com/backendoori/ootw/user/dto/SendCodeDto.java
+++ b/src/main/java/com/backendoori/ootw/user/dto/SendCodeDto.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record SendCertificateDto(
+public record SendCodeDto(
     @NotNull
     @NotBlank
     @Size(max = 255)

--- a/src/main/java/com/backendoori/ootw/user/dto/SignupDto.java
+++ b/src/main/java/com/backendoori/ootw/user/dto/SignupDto.java
@@ -5,21 +5,17 @@ import com.backendoori.ootw.user.validation.Password;
 import com.backendoori.ootw.user.validation.RFC5322;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record SignupDto(
-    @NotNull
     @NotBlank
     @Size(max = 255)
     @Email(regexp = RFC5322.REGEX)
     String email,
 
-    @NotNull
     @Password
     String password,
 
-    @NotNull
     @Size(max = 255)
     @NotBlank(message = Message.BLANK_NICKNAME)
     String nickname

--- a/src/main/java/com/backendoori/ootw/user/service/CertificateService.java
+++ b/src/main/java/com/backendoori/ootw/user/service/CertificateService.java
@@ -34,7 +34,7 @@ public class CertificateService {
         User user = userRepository.findByEmail(email)
             .orElseThrow(UserNotFoundException::new);
 
-        AssertUtil.throwIf(user.getCertified(), AlreadyCertifiedUserException::new);
+        AssertUtil.throwIf(user.isCertified(), AlreadyCertifiedUserException::new);
 
         Certificate certificate = generateCertificate(email);
         String title = generateTitle(certificate);
@@ -48,7 +48,7 @@ public class CertificateService {
         User user = userRepository.findByEmail(certifyDto.email())
             .orElseThrow(UserNotFoundException::new);
 
-        AssertUtil.throwIf(user.getCertified(), AlreadyCertifiedUserException::new);
+        AssertUtil.throwIf(user.isCertified(), AlreadyCertifiedUserException::new);
 
         Certificate certificate = certificateRedisRepository.findById(certifyDto.email())
             .orElseThrow(UserNotFoundException::new);

--- a/src/main/java/com/backendoori/ootw/user/service/CertificateService.java
+++ b/src/main/java/com/backendoori/ootw/user/service/CertificateService.java
@@ -28,7 +28,7 @@ public class CertificateService {
     private final CertificateRedisRepository certificateRedisRepository;
 
     @Transactional
-    public void sendCertificate(SendCodeDto sendCodeDto) {
+    public void sendCode(SendCodeDto sendCodeDto) {
         String email = sendCodeDto.email();
 
         User user = userRepository.findByEmail(email)

--- a/src/main/java/com/backendoori/ootw/user/service/CertificateService.java
+++ b/src/main/java/com/backendoori/ootw/user/service/CertificateService.java
@@ -7,7 +7,7 @@ import com.backendoori.ootw.exception.UserNotFoundException;
 import com.backendoori.ootw.user.domain.Certificate;
 import com.backendoori.ootw.user.domain.User;
 import com.backendoori.ootw.user.dto.CertifyDto;
-import com.backendoori.ootw.user.dto.SendCertificateDto;
+import com.backendoori.ootw.user.dto.SendCodeDto;
 import com.backendoori.ootw.user.exception.AlreadyCertifiedUserException;
 import com.backendoori.ootw.user.exception.IncorrectCertificateException;
 import com.backendoori.ootw.user.repository.CertificateRedisRepository;
@@ -28,8 +28,8 @@ public class CertificateService {
     private final CertificateRedisRepository certificateRedisRepository;
 
     @Transactional
-    public void sendCertificate(SendCertificateDto sendCertificateDto) {
-        String email = sendCertificateDto.email();
+    public void sendCertificate(SendCodeDto sendCodeDto) {
+        String email = sendCodeDto.email();
 
         User user = userRepository.findByEmail(email)
             .orElseThrow(UserNotFoundException::new);

--- a/src/main/java/com/backendoori/ootw/user/service/UserService.java
+++ b/src/main/java/com/backendoori/ootw/user/service/UserService.java
@@ -71,7 +71,7 @@ public class UserService {
     }
 
     private void validateLogin(User user, String decrypted) {
-        AssertUtil.throwIf(!user.getCertified(), NonCertifiedUserException::new);
+        AssertUtil.throwIf(!user.isCertified(), NonCertifiedUserException::new);
         AssertUtil.throwIf(!user.matchPassword(passwordEncoder, decrypted), IncorrectPasswordException::new);
     }
 

--- a/src/main/java/com/backendoori/ootw/user/service/UserService.java
+++ b/src/main/java/com/backendoori/ootw/user/service/UserService.java
@@ -36,7 +36,7 @@ public class UserService {
         User user = buildUser(signupDto);
 
         userRepository.save(user);
-        certificateService.sendCertificate(new SendCodeDto(user.getEmail()));
+        certificateService.sendCode(new SendCodeDto(user.getEmail()));
     }
 
     public TokenDto login(LoginDto loginDto) {

--- a/src/main/java/com/backendoori/ootw/user/service/UserService.java
+++ b/src/main/java/com/backendoori/ootw/user/service/UserService.java
@@ -5,7 +5,7 @@ import com.backendoori.ootw.exception.UserNotFoundException;
 import com.backendoori.ootw.security.jwt.TokenProvider;
 import com.backendoori.ootw.user.domain.User;
 import com.backendoori.ootw.user.dto.LoginDto;
-import com.backendoori.ootw.user.dto.SendCertificateDto;
+import com.backendoori.ootw.user.dto.SendCodeDto;
 import com.backendoori.ootw.user.dto.SignupDto;
 import com.backendoori.ootw.user.dto.TokenDto;
 import com.backendoori.ootw.user.exception.AlreadyExistEmailException;
@@ -36,7 +36,7 @@ public class UserService {
         User user = buildUser(signupDto);
 
         userRepository.save(user);
-        certificateService.sendCertificate(new SendCertificateDto(user.getEmail()));
+        certificateService.sendCertificate(new SendCodeDto(user.getEmail()));
     }
 
     public TokenDto login(LoginDto loginDto) {

--- a/src/test/java/com/backendoori/ootw/common/OotwMailSenderTest.java
+++ b/src/test/java/com/backendoori/ootw/common/OotwMailSenderTest.java
@@ -7,9 +7,13 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
+@ExtendWith(OutputCaptureExtension.class)
 @SpringBootTest
 class OotwMailSenderTest extends MailTest {
 
@@ -27,7 +31,7 @@ class OotwMailSenderTest extends MailTest {
         ootwMailSender.sendMail(SMTP_ADDRESS, title, body);
 
         // then
-        smtp.waitForIncomingEmail(30 * 1000L, 1);
+        smtp.waitForIncomingEmail(5 * 1000L, 1);
 
         MimeMessage[] receivedMessages = smtp.getReceivedMessages();
         MimeMessage message = receivedMessages[0];
@@ -36,6 +40,27 @@ class OotwMailSenderTest extends MailTest {
         assertThat(receivedMessages).hasSize(1);
         assertThat(actualReceiver).isEqualTo(SMTP_ADDRESS);
         assertThat(GreenMailUtil.getBody(message)).isEqualTo(body);
+    }
+
+    @DisplayName("메일 전송에 실패할 경우 예외를 logging 한다")
+    @Test
+    void testSendMailLoggingException(CapturedOutput output) {
+        // given
+        String title = GreenMailUtil.random();
+        String body = GreenMailUtil.random();
+
+        // when
+        ootwMailSender.sendMail("", title, body);
+
+        // then
+        smtp.waitForIncomingEmail(5 * 1000L, 1);
+
+        MimeMessage[] receivedMessages = smtp.getReceivedMessages();
+
+        assertThat(receivedMessages).isEmpty();
+        assertThat(output.getOut())
+            .contains("ERROR")
+            .contains("Fail to send email");
     }
 
 }

--- a/src/test/java/com/backendoori/ootw/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/backendoori/ootw/like/controller/LikeControllerTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,7 +85,7 @@ class LikeControllerTest extends TokenMockMvcTest {
             .email(FAKER.internet().emailAddress())
             .password(FAKER.internet().password())
             .nickname(FAKER.internet().username())
-            .image(FAKER.internet().url())
+            .profileImageUrl(FAKER.internet().url())
             .certified(true)
             .build();
     }
@@ -114,7 +113,7 @@ class LikeControllerTest extends TokenMockMvcTest {
         LikeRequest request = new LikeRequest(post.getId());
 
         //when
-        mockMvc.perform(post("http://localhost:8080/api/v1/posts/"+ post.getId()+ "/likes")
+        mockMvc.perform(post("http://localhost:8080/api/v1/posts/" + post.getId() + "/likes")
                 .content(objectMapper.writeValueAsBytes(request))
                 .header(TOKEN_HEADER, TOKEN_PREFIX + token)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -142,7 +141,7 @@ class LikeControllerTest extends TokenMockMvcTest {
         LikeRequest request = new LikeRequest(post.getId());
 
         //when
-        mockMvc.perform(post("http://localhost:8080/api/v1/posts/"+ post.getId()+ "/likes")
+        mockMvc.perform(post("http://localhost:8080/api/v1/posts/" + post.getId() + "/likes")
                 .content(objectMapper.writeValueAsBytes(request))
                 .header(TOKEN_HEADER, TOKEN_PREFIX + token)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -167,7 +166,7 @@ class LikeControllerTest extends TokenMockMvcTest {
         LikeRequest request = new LikeRequest(postId);
 
         //when //then
-        mockMvc.perform(post("http://localhost:8080/api/v1/posts/"+ postId + "/likes")
+        mockMvc.perform(post("http://localhost:8080/api/v1/posts/" + postId + "/likes")
                 .content(objectMapper.writeValueAsBytes(request))
                 .header(TOKEN_HEADER, TOKEN_PREFIX + token)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -185,7 +184,7 @@ class LikeControllerTest extends TokenMockMvcTest {
         LikeRequest request = new LikeRequest(postId);
 
         //when //then
-        mockMvc.perform(post("http://localhost:8080/api/v1/posts/"+ postId+ "/likes")
+        mockMvc.perform(post("http://localhost:8080/api/v1/posts/" + postId + "/likes")
                 .content(objectMapper.writeValueAsBytes(request))
                 .header(TOKEN_HEADER, TOKEN_PREFIX + token)
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/backendoori/ootw/like/domain/LikeTest.java
+++ b/src/test/java/com/backendoori/ootw/like/domain/LikeTest.java
@@ -28,7 +28,7 @@ class LikeTest {
             .email(FAKER.internet().emailAddress())
             .password(FAKER.internet().password())
             .nickname(FAKER.internet().username())
-            .image(FAKER.internet().url())
+            .profileImageUrl(FAKER.internet().url())
             .build();
     }
 

--- a/src/test/java/com/backendoori/ootw/like/service/LikeServiceTest.java
+++ b/src/test/java/com/backendoori/ootw/like/service/LikeServiceTest.java
@@ -3,15 +3,11 @@ package com.backendoori.ootw.like.service;
 import static com.backendoori.ootw.util.provider.ForecastApiCommonRequestSourceProvider.VALID_COORDINATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -95,7 +91,7 @@ public class LikeServiceTest extends TokenMockMvcTest {
             .email(FAKER.internet().emailAddress())
             .password(FAKER.internet().password())
             .nickname(FAKER.internet().username())
-            .image(FAKER.internet().url())
+            .profileImageUrl(FAKER.internet().url())
             .certified(true)
             .build();
     }

--- a/src/test/java/com/backendoori/ootw/post/controller/PostControllerTest.java
+++ b/src/test/java/com/backendoori/ootw/post/controller/PostControllerTest.java
@@ -47,6 +47,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 @TestInstance(Lifecycle.PER_CLASS)
 class PostControllerTest extends TokenMockMvcTest {
+
     static final Faker FAKER = new Faker();
 
     User user;
@@ -87,7 +88,7 @@ class PostControllerTest extends TokenMockMvcTest {
             .email(FAKER.internet().emailAddress())
             .password(FAKER.internet().password())
             .nickname(FAKER.internet().username())
-            .image(FAKER.internet().url())
+            .profileImageUrl(FAKER.internet().url())
             .certified(true)
             .build();
     }

--- a/src/test/java/com/backendoori/ootw/post/service/PostServiceTest.java
+++ b/src/test/java/com/backendoori/ootw/post/service/PostServiceTest.java
@@ -401,7 +401,7 @@ class PostServiceTest {
             .email(FAKER.internet().emailAddress())
             .password(FAKER.internet().password())
             .nickname(FAKER.internet().username())
-            .image(FAKER.internet().url())
+            .profileImageUrl(FAKER.internet().url())
             .certified(true)
             .build();
     }

--- a/src/test/java/com/backendoori/ootw/security/jwt/TokenProviderTest.java
+++ b/src/test/java/com/backendoori/ootw/security/jwt/TokenProviderTest.java
@@ -19,7 +19,7 @@ import org.springframework.security.core.GrantedAuthority;
 
 class TokenProviderTest {
 
-    static Faker faker = new Faker();
+    static final Faker FAKER = new Faker();
 
     String issuer;
     SecretKey key;
@@ -29,10 +29,10 @@ class TokenProviderTest {
 
     @BeforeEach
     void setup() {
-        issuer = faker.name().firstName();
+        issuer = FAKER.name().firstName();
         key = generateSecretKey();
         encodedKey = encodeBytes(key.getEncoded());
-        tokenValidityInSeconds = faker.number().numberBetween(10, Integer.MAX_VALUE);
+        tokenValidityInSeconds = FAKER.number().numberBetween(10, Integer.MAX_VALUE);
         tokenProvider = createTokenProvider(issuer, encodedKey, tokenValidityInSeconds);
     }
 
@@ -40,7 +40,7 @@ class TokenProviderTest {
     @Test
     void testCreateToken() {
         // given
-        long userId = faker.number().positive();
+        long userId = FAKER.number().positive();
 
         // when
         String token = tokenProvider.createToken(userId);
@@ -61,7 +61,7 @@ class TokenProviderTest {
     @Test
     void testGetAuthentication() {
         // given
-        long userId = faker.number().positive();
+        long userId = FAKER.number().positive();
 
         String token = tokenProvider.createToken(userId);
 
@@ -121,7 +121,7 @@ class TokenProviderTest {
         @Test
         void success() {
             // given
-            long userId = faker.number().positive();
+            long userId = FAKER.number().positive();
 
             String token = tokenProvider.createToken(userId);
 
@@ -135,7 +135,7 @@ class TokenProviderTest {
         @DisplayName("잘못된 형식의 토큰은 false를 반환한다")
         @Test
         void failMalformed() {
-            long userId = faker.number().positive();
+            long userId = FAKER.number().positive();
 
             String token = tokenProvider.createToken(userId);
             String malformed = token.replace(".", "..");
@@ -150,7 +150,7 @@ class TokenProviderTest {
         @DisplayName("위조된 토큰은 false를 반환한다")
         @Test
         void failForged() {
-            long userId = faker.number().positive();
+            long userId = FAKER.number().positive();
 
             String token = tokenProvider.createToken(userId);
             String forgedToken = forgeToken(token, userId);
@@ -166,9 +166,9 @@ class TokenProviderTest {
         @Test
         void failOtherIssuer() {
             // given
-            String otherIssuer = faker.name().firstName();
+            String otherIssuer = FAKER.name().firstName();
             TokenProvider otherTokenProvider = createTokenProvider(otherIssuer, encodedKey, tokenValidityInSeconds);
-            long userId = faker.number().positive();
+            long userId = FAKER.number().positive();
 
             String otherToken = otherTokenProvider.createToken(userId);
 
@@ -185,7 +185,7 @@ class TokenProviderTest {
             // given
             String otherKey = encodeBytes(generateSecretKey().getEncoded());
             TokenProvider otherTokenProvider = createTokenProvider(issuer, otherKey, tokenValidityInSeconds);
-            long userId = faker.number().positive();
+            long userId = FAKER.number().positive();
 
             String otherToken = otherTokenProvider.createToken(userId);
 
@@ -200,7 +200,7 @@ class TokenProviderTest {
         @Test
         void failUnsupported() {
             // given
-            long userId = faker.number().positive();
+            long userId = FAKER.number().positive();
 
             String token = tokenProvider.createToken(userId);
             String unSecuredToken = unSecureToken(token);
@@ -217,7 +217,7 @@ class TokenProviderTest {
         void failExpiredJwt() {
             // given
             tokenProvider = createTokenProvider(issuer, encodedKey, 0);
-            long userId = faker.number().positive();
+            long userId = FAKER.number().positive();
             String token = tokenProvider.createToken(userId);
 
             // when

--- a/src/test/java/com/backendoori/ootw/user/controller/CertificateControllerTest.java
+++ b/src/test/java/com/backendoori/ootw/user/controller/CertificateControllerTest.java
@@ -10,7 +10,7 @@ import com.backendoori.ootw.exception.UserNotFoundException;
 import com.backendoori.ootw.security.jwt.TokenProvider;
 import com.backendoori.ootw.user.domain.Certificate;
 import com.backendoori.ootw.user.dto.CertifyDto;
-import com.backendoori.ootw.user.dto.SendCertificateDto;
+import com.backendoori.ootw.user.dto.SendCodeDto;
 import com.backendoori.ootw.user.exception.AlreadyCertifiedUserException;
 import com.backendoori.ootw.user.exception.IncorrectCertificateException;
 import com.backendoori.ootw.user.service.CertificateService;
@@ -53,11 +53,11 @@ class CertificateControllerTest {
     @Nested
     class CertificationTest {
 
-        SendCertificateDto sendCertificateDto;
+        SendCodeDto sendCodeDto;
 
         @BeforeEach
         void setSendCertificateDto() {
-            sendCertificateDto = new SendCertificateDto(FAKER.internet().emailAddress());
+            sendCodeDto = new SendCodeDto(FAKER.internet().emailAddress());
         }
 
         @DisplayName("인증 코드 발송에 성공할 경우 200 status를 반환한다.")
@@ -66,7 +66,7 @@ class CertificateControllerTest {
             // given
             MockHttpServletRequestBuilder requestBuilder = patch("/api/v1/auth/certificate")
                 .with(csrf())
-                .param("email", sendCertificateDto.email())
+                .param("email", sendCodeDto.email())
                 .contentType(MediaType.APPLICATION_JSON);
 
             // when
@@ -82,12 +82,12 @@ class CertificateControllerTest {
             // given
             MockHttpServletRequestBuilder requestBuilder = patch("/api/v1/auth/certificate")
                 .with(csrf())
-                .param("email", sendCertificateDto.email())
+                .param("email", sendCodeDto.email())
                 .contentType(MediaType.APPLICATION_JSON);
 
             doThrow(AlreadyCertifiedUserException.class)
                 .when(certificateService)
-                .sendCertificate(sendCertificateDto);
+                .sendCertificate(sendCodeDto);
 
             // when
             ResultActions actions = mockMvc.perform(requestBuilder);

--- a/src/test/java/com/backendoori/ootw/user/controller/CertificateControllerTest.java
+++ b/src/test/java/com/backendoori/ootw/user/controller/CertificateControllerTest.java
@@ -56,7 +56,7 @@ class CertificateControllerTest {
         SendCodeDto sendCodeDto;
 
         @BeforeEach
-        void setSendCertificateDto() {
+        void setSendCodeDto() {
             sendCodeDto = new SendCodeDto(FAKER.internet().emailAddress());
         }
 
@@ -87,7 +87,7 @@ class CertificateControllerTest {
 
             doThrow(AlreadyCertifiedUserException.class)
                 .when(certificateService)
-                .sendCertificate(sendCodeDto);
+                .sendCode(sendCodeDto);
 
             // when
             ResultActions actions = mockMvc.perform(requestBuilder);

--- a/src/test/java/com/backendoori/ootw/user/controller/UserControllerTest.java
+++ b/src/test/java/com/backendoori/ootw/user/controller/UserControllerTest.java
@@ -43,7 +43,7 @@ import org.springframework.test.web.servlet.ResultActions;
 @WebMvcTest(UserController.class)
 class UserControllerTest {
 
-    static Faker faker = new Faker();
+    static final Faker FAKER = new Faker();
 
     @Autowired
     MockMvc mockMvc;
@@ -82,8 +82,8 @@ class UserControllerTest {
         @ParameterizedTest
         void badRequestInvalidEmail(String email) throws Exception {
             // given
-            String password = faker.internet().password(8, 30, true, true, true);
-            String nickname = faker.internet().username();
+            String password = FAKER.internet().password(8, 30, true, true, true);
+            String nickname = FAKER.internet().username();
             SignupDto signupDto = new SignupDto(email, password, nickname);
 
             // when
@@ -103,8 +103,8 @@ class UserControllerTest {
         @ParameterizedTest
         void badRequestInvalidPassword(String password) throws Exception {
             // given
-            String email = faker.internet().emailAddress();
-            String nickname = faker.internet().username();
+            String email = FAKER.internet().emailAddress();
+            String nickname = FAKER.internet().username();
             SignupDto signupDto = new SignupDto(email, password, nickname);
 
             // when
@@ -123,8 +123,8 @@ class UserControllerTest {
         @ParameterizedTest
         void badRequestBlankNickname(String nickname) throws Exception {
             // given
-            String email = faker.internet().emailAddress();
-            String password = faker.internet().password(8, 30, true, true, true);
+            String email = FAKER.internet().emailAddress();
+            String password = FAKER.internet().password(8, 30, true, true, true);
             SignupDto signupDto = new SignupDto(email, password, nickname);
 
             // when
@@ -170,7 +170,7 @@ class UserControllerTest {
         void created() throws Exception {
             // given
             LoginDto loginDto = generateLoginDto();
-            TokenDto tokenDto = new TokenDto(faker.hashing().sha512());
+            TokenDto tokenDto = new TokenDto(FAKER.hashing().sha512());
 
             given(userService.login(loginDto)).willReturn(tokenDto);
 
@@ -192,7 +192,7 @@ class UserControllerTest {
         @ParameterizedTest
         void badRequestInvalidEmail(String email) throws Exception {
             // given
-            String password = faker.internet().password(8, 30, true, true, true);
+            String password = FAKER.internet().password(8, 30, true, true, true);
             LoginDto loginDto = new LoginDto(email, password);
 
             // when
@@ -250,7 +250,7 @@ class UserControllerTest {
         @ParameterizedTest
         void badRequestInvalidPassword(String password) throws Exception {
             // given
-            String email = faker.internet().emailAddress();
+            String email = FAKER.internet().emailAddress();
             LoginDto loginDto = new LoginDto(email, password);
 
             // when
@@ -286,16 +286,16 @@ class UserControllerTest {
     }
 
     private SignupDto generateSignupDto() {
-        String email = faker.internet().emailAddress();
-        String password = faker.internet().password(8, 30, true, true, true);
-        String nickname = faker.internet().username();
+        String email = FAKER.internet().emailAddress();
+        String password = FAKER.internet().password(8, 30, true, true, true);
+        String nickname = FAKER.internet().username();
 
         return new SignupDto(email, password, nickname);
     }
 
     private LoginDto generateLoginDto() {
-        String email = faker.internet().emailAddress();
-        String password = faker.internet().password(8, 30, true, true, true);
+        String email = FAKER.internet().emailAddress();
+        String password = FAKER.internet().password(8, 30, true, true, true);
 
         return new LoginDto(email, password);
     }
@@ -309,12 +309,12 @@ class UserControllerTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
-                Arguments.of(faker.app().name()),
-                Arguments.of(faker.name().fullName()),
-                Arguments.of(faker.internet().url()),
-                Arguments.of(faker.internet().domainName()),
-                Arguments.of(faker.internet().webdomain()),
-                Arguments.of(faker.internet().botUserAgentAny())
+                Arguments.of(FAKER.app().name()),
+                Arguments.of(FAKER.name().fullName()),
+                Arguments.of(FAKER.internet().url()),
+                Arguments.of(FAKER.internet().domainName()),
+                Arguments.of(FAKER.internet().webdomain()),
+                Arguments.of(FAKER.internet().botUserAgentAny())
             );
         }
 
@@ -325,10 +325,10 @@ class UserControllerTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
-                Arguments.of(faker.internet().password(1, 7, true, true, true)),
-                Arguments.of(faker.internet().password(31, 50, true, true, true)),
-                Arguments.of(faker.internet().password(8, 30, true, false, true)),
-                Arguments.of(faker.internet().password(8, 30, true, true, false))
+                Arguments.of(FAKER.internet().password(1, 7, true, true, true)),
+                Arguments.of(FAKER.internet().password(31, 50, true, true, true)),
+                Arguments.of(FAKER.internet().password(8, 30, true, false, true)),
+                Arguments.of(FAKER.internet().password(8, 30, true, true, false))
             );
         }
 

--- a/src/test/java/com/backendoori/ootw/user/domain/UserTest.java
+++ b/src/test/java/com/backendoori/ootw/user/domain/UserTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class UserTest {
 
-    static final Faker faker = new Faker();
+    static final Faker FAKER = new Faker();
 
     Long id;
     String email;
@@ -26,11 +26,11 @@ class UserTest {
 
     @BeforeEach
     void setup() {
-        id = (long) faker.number().positive();
-        email = faker.internet().emailAddress();
-        password = faker.internet().password();
-        nickname = faker.internet().username();
-        image = faker.internet().url();
+        id = (long) FAKER.number().positive();
+        email = FAKER.internet().emailAddress();
+        password = FAKER.internet().password();
+        nickname = FAKER.internet().username();
+        image = FAKER.internet().url();
     }
 
     @DisplayName("instance 생성에 성공한다.")
@@ -66,7 +66,7 @@ class UserTest {
     @Test
     void testCreateTooLongEmail() {
         // given
-        this.email = faker.natoPhoneticAlphabet().codeWord().repeat(65) + "@" + faker.internet().domainName();
+        this.email = FAKER.natoPhoneticAlphabet().codeWord().repeat(65) + "@" + FAKER.internet().domainName();
 
         // when
         ThrowingCallable createUser = this::buildUser;
@@ -113,7 +113,7 @@ class UserTest {
     @Test
     void testCreateTooLongNickname() {
         // given
-        this.nickname = faker.natoPhoneticAlphabet().codeWord().repeat(65);
+        this.nickname = FAKER.natoPhoneticAlphabet().codeWord().repeat(65);
 
         // when
         ThrowingCallable createUser = this::buildUser;
@@ -126,12 +126,12 @@ class UserTest {
 
     private static Stream<String> generateInvalidEmails() {
         return Stream.of(
-            faker.app().name(),
-            faker.name().fullName(),
-            faker.internet().url(),
-            faker.internet().domainName(),
-            faker.internet().webdomain(),
-            faker.internet().botUserAgentAny()
+            FAKER.app().name(),
+            FAKER.name().fullName(),
+            FAKER.internet().url(),
+            FAKER.internet().domainName(),
+            FAKER.internet().webdomain(),
+            FAKER.internet().botUserAgentAny()
         );
     }
 

--- a/src/test/java/com/backendoori/ootw/user/domain/UserTest.java
+++ b/src/test/java/com/backendoori/ootw/user/domain/UserTest.java
@@ -141,7 +141,7 @@ class UserTest {
             .email(email)
             .password(password)
             .nickname(nickname)
-            .image(image)
+            .profileImageUrl(image)
             .certified(false)
             .build();
     }

--- a/src/test/java/com/backendoori/ootw/user/service/CertificateServiceTest.java
+++ b/src/test/java/com/backendoori/ootw/user/service/CertificateServiceTest.java
@@ -46,7 +46,7 @@ class CertificateServiceTest extends MailTest {
             .email(SMTP_ADDRESS)
             .password(FAKER.internet().password())
             .nickname(FAKER.internet().username())
-            .image(FAKER.internet().url())
+            .profileImageUrl(FAKER.internet().url())
             .certified(false)
             .build();
 
@@ -132,7 +132,7 @@ class CertificateServiceTest extends MailTest {
             User actualUser = userRepository.findById(user.getId())
                 .orElseThrow();
 
-            assertThat(actualUser.getCertified()).isTrue();
+            assertThat(actualUser.isCertified()).isTrue();
         }
 
         @DisplayName("존재하지 않는 사용자에 대한 인증 요청은 예외가 발생한다")

--- a/src/test/java/com/backendoori/ootw/user/service/CertificateServiceTest.java
+++ b/src/test/java/com/backendoori/ootw/user/service/CertificateServiceTest.java
@@ -61,12 +61,12 @@ class CertificateServiceTest extends MailTest {
 
     @DisplayName("인증 코드 발송 테스트")
     @Nested
-    class SendCertificateTest {
+    class SendCodeTest {
 
         SendCodeDto sendCodeDto;
 
         @BeforeEach
-        void setSendCertificateDto() {
+        void setSendCodeDto() {
             sendCodeDto = new SendCodeDto(user.getEmail());
         }
 
@@ -74,7 +74,7 @@ class CertificateServiceTest extends MailTest {
         @Test
         void success() {
             // given // when
-            certificateService.sendCertificate(sendCodeDto);
+            certificateService.sendCode(sendCodeDto);
 
             // then
             smtp.waitForIncomingEmail(30 * 1000L, 1);
@@ -94,7 +94,7 @@ class CertificateServiceTest extends MailTest {
             userRepository.save(user);
 
             // when
-            ThrowingCallable sendCertificate = () -> certificateService.sendCertificate(sendCodeDto);
+            ThrowingCallable sendCertificate = () -> certificateService.sendCode(sendCodeDto);
 
             // then
             assertThatExceptionOfType(AlreadyCertifiedUserException.class)

--- a/src/test/java/com/backendoori/ootw/user/service/CertificateServiceTest.java
+++ b/src/test/java/com/backendoori/ootw/user/service/CertificateServiceTest.java
@@ -8,7 +8,7 @@ import com.backendoori.ootw.exception.UserNotFoundException;
 import com.backendoori.ootw.user.domain.Certificate;
 import com.backendoori.ootw.user.domain.User;
 import com.backendoori.ootw.user.dto.CertifyDto;
-import com.backendoori.ootw.user.dto.SendCertificateDto;
+import com.backendoori.ootw.user.dto.SendCodeDto;
 import com.backendoori.ootw.user.exception.AlreadyCertifiedUserException;
 import com.backendoori.ootw.user.exception.IncorrectCertificateException;
 import com.backendoori.ootw.user.repository.CertificateRedisRepository;
@@ -63,18 +63,18 @@ class CertificateServiceTest extends MailTest {
     @Nested
     class SendCertificateTest {
 
-        SendCertificateDto sendCertificateDto;
+        SendCodeDto sendCodeDto;
 
         @BeforeEach
         void setSendCertificateDto() {
-            sendCertificateDto = new SendCertificateDto(user.getEmail());
+            sendCodeDto = new SendCodeDto(user.getEmail());
         }
 
         @DisplayName("사용자 이메일로 인증 코드를 보내는데 성공한다")
         @Test
         void success() {
             // given // when
-            certificateService.sendCertificate(sendCertificateDto);
+            certificateService.sendCertificate(sendCodeDto);
 
             // then
             smtp.waitForIncomingEmail(30 * 1000L, 1);
@@ -94,7 +94,7 @@ class CertificateServiceTest extends MailTest {
             userRepository.save(user);
 
             // when
-            ThrowingCallable sendCertificate = () -> certificateService.sendCertificate(sendCertificateDto);
+            ThrowingCallable sendCertificate = () -> certificateService.sendCertificate(sendCodeDto);
 
             // then
             assertThatExceptionOfType(AlreadyCertifiedUserException.class)

--- a/src/test/java/com/backendoori/ootw/user/service/UserServiceTest.java
+++ b/src/test/java/com/backendoori/ootw/user/service/UserServiceTest.java
@@ -212,7 +212,7 @@ class UserServiceTest {
             .email(faker.internet().emailAddress())
             .password(passwordEncoder.encode(password))
             .nickname(faker.internet().username())
-            .image(faker.internet().url())
+            .profileImageUrl(faker.internet().url())
             .certified(certified)
             .build();
     }

--- a/src/test/java/com/backendoori/ootw/user/service/UserServiceTest.java
+++ b/src/test/java/com/backendoori/ootw/user/service/UserServiceTest.java
@@ -37,7 +37,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @TestInstance(Lifecycle.PER_CLASS)
 class UserServiceTest {
 
-    static Faker faker = new Faker();
+    static final Faker FAKER = new Faker();
 
     @Autowired
     PasswordEncoder passwordEncoder;
@@ -108,10 +108,10 @@ class UserServiceTest {
 
         private static Stream<String> generateInvalidPasswords() {
             return Stream.of(
-                faker.internet().password(1, 7, true, true, true),
-                faker.internet().password(31, 50, true, true, true),
-                faker.internet().password(8, 30, true, false, true),
-                faker.internet().password(8, 30, true, true, false)
+                FAKER.internet().password(1, 7, true, true, true),
+                FAKER.internet().password(31, 50, true, true, true),
+                FAKER.internet().password(8, 30, true, false, true),
+                FAKER.internet().password(8, 30, true, true, false)
             );
         }
 
@@ -125,7 +125,7 @@ class UserServiceTest {
         @Test
         void success() {
             // given
-            String password = faker.internet().password();
+            String password = FAKER.internet().password();
             User user = userRepository.save(generateUser(password, true));
             LoginDto loginDto = new LoginDto(user.getEmail(), password);
 
@@ -143,7 +143,7 @@ class UserServiceTest {
         @Test
         void failUserNotFound() {
             // given
-            String password = faker.internet().password();
+            String password = FAKER.internet().password();
             User user = generateUser(password);
             LoginDto loginDto = new LoginDto(user.getEmail(), password + password);
 
@@ -160,7 +160,7 @@ class UserServiceTest {
         @Test
         void failIncorrectPassword() {
             // given
-            String password = faker.internet().password();
+            String password = FAKER.internet().password();
             User user = userRepository.save(generateUser(password, true));
             LoginDto loginDto = new LoginDto(user.getEmail(), password + password);
 
@@ -177,7 +177,7 @@ class UserServiceTest {
         @Test
         void failNonCertified() {
             // given
-            String password = faker.internet().password();
+            String password = FAKER.internet().password();
             User user = userRepository.save(generateUser(password, false));
             LoginDto loginDto = new LoginDto(user.getEmail(), password + password);
 
@@ -193,12 +193,12 @@ class UserServiceTest {
     }
 
     private SignupDto generateSignupDto() {
-        return generateSignupDto(faker.internet().password(8, 30, true, true, true));
+        return generateSignupDto(FAKER.internet().password(8, 30, true, true, true));
     }
 
     private SignupDto generateSignupDto(String password) {
-        String email = faker.internet().emailAddress();
-        String nickname = faker.internet().username();
+        String email = FAKER.internet().emailAddress();
+        String nickname = FAKER.internet().username();
 
         return new SignupDto(email, password, nickname);
     }
@@ -209,10 +209,10 @@ class UserServiceTest {
 
     private User generateUser(String password, boolean certified) {
         return User.builder()
-            .email(faker.internet().emailAddress())
+            .email(FAKER.internet().emailAddress())
             .password(passwordEncoder.encode(password))
-            .nickname(faker.internet().username())
-            .profileImageUrl(faker.internet().url())
+            .nickname(FAKER.internet().username())
+            .profileImageUrl(FAKER.internet().url())
             .certified(certified)
             .build();
     }


### PR DESCRIPTION
## ✅ 요구사항 
- #59 
- #62 

## 🚀 주요 변경사항
- `User` 도메인 field rename
  - `image` -> `profileImageUrl`
- `TokenProvider` 로깅 메시지 분리
- 이메일 전송 실패 테스트 추가
- 필요없는 validate annotation 제거
- 인증 코드 전송 메서드 명 수정
  - `sendCertificate` -> `sendCode`
- Config 패키지 파일의 annotation 통일
- Test `Faker` 필드 명 통일
