### PR TITLE
🚀 API 서버 타임 존 설정

### DIFF
--- a/src/main/java/com/backendoori/ootw/OotwApplication.java
+++ b/src/main/java/com/backendoori/ootw/OotwApplication.java
@@ -1,5 +1,7 @@
 package com.backendoori.ootw;
 
+import java.util.TimeZone;
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -8,8 +10,15 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 @ConfigurationPropertiesScan
 public class OotwApplication {
 
+    public static final String TIMEZONE = "Asia/Seoul";
+
     public static void main(String[] args) {
         SpringApplication.run(OotwApplication.class, args);
+    }
+
+    @PostConstruct
+    public void setTimezone() {
+        TimeZone.setDefault(TimeZone.getTimeZone(TIMEZONE));
     }
 
 }

--- a/src/test/java/com/backendoori/ootw/OotwApplicationTests.java
+++ b/src/test/java/com/backendoori/ootw/OotwApplicationTests.java
@@ -25,7 +25,7 @@ class OotwApplicationTests {
         assertThatNoException().isThrownBy(main);
     }
 
-    @DisplayName("애플리케이션 서버 시간이 설정된다")
+    @DisplayName("애플리케이션을 지정된 Tiemzone으로 설정한다")
     @Test
     void testServerTimezone() {
         // given // when

--- a/src/test/java/com/backendoori/ootw/OotwApplicationTests.java
+++ b/src/test/java/com/backendoori/ootw/OotwApplicationTests.java
@@ -1,7 +1,9 @@
 package com.backendoori.ootw;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import java.util.TimeZone;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,16 @@ class OotwApplicationTests {
 
         // then
         assertThatNoException().isThrownBy(main);
+    }
+
+    @DisplayName("애플리케이션 서버 시간이 설정된다")
+    @Test
+    void testServerTimezone() {
+        // given // when
+        String id = TimeZone.getDefault().getID();
+
+        // then
+        assertThat(id).isEqualTo(OotwApplication.TIMEZONE);
     }
 
 }


### PR DESCRIPTION
## ✅ 요구사항 
- #67 

## 🚀 주요 변경사항
- [x] `@PostConstruct` annotation으로 서버 타임 존 설정
- [x] 서버 타임 존 테스트 코드 추가

## 💡 기타사항
<!-- ex) 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
- `America/NewYork` 같은 Timezone은 자동으로 `GMT` (그리니치 천문대 기준)로 설정됨
  - 따라서 해당 타임 존의 경우 현재 테스트 코드로는 통과가 안됨
  - 해당 프로젝트가 `Asia/Seoul`을 기준으로 하기 때문에 해결해야할 이슈는 아니라고 생각