### PR TITLE
🚀 Redis TTL 설정을 통한 이메일 인증 만료 기능 추가

### DIFF
--- a/src/main/java/com/backendoori/ootw/user/domain/Certificate.java
+++ b/src/main/java/com/backendoori/ootw/user/domain/Certificate.java
@@ -11,7 +11,7 @@ import org.springframework.data.redis.core.RedisHash;
 
 @Getter
 @Builder
-@RedisHash("certificate")
+@RedisHash(value = "certificate", timeToLive = 10 * 60L)
 public class Certificate {
 
     public static final int SIZE = 6;

--- a/src/main/java/com/backendoori/ootw/user/exception/ExpiredCertificateException.java
+++ b/src/main/java/com/backendoori/ootw/user/exception/ExpiredCertificateException.java
@@ -1,0 +1,11 @@
+package com.backendoori.ootw.user.exception;
+
+public class ExpiredCertificateException extends IllegalArgumentException {
+
+    public static final String DEFAULT_MESSAGE = "만료된 인증 코드 입니다.";
+
+    public ExpiredCertificateException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+}

--- a/src/main/java/com/backendoori/ootw/user/service/CertificateService.java
+++ b/src/main/java/com/backendoori/ootw/user/service/CertificateService.java
@@ -9,6 +9,7 @@ import com.backendoori.ootw.user.domain.User;
 import com.backendoori.ootw.user.dto.CertifyDto;
 import com.backendoori.ootw.user.dto.SendCodeDto;
 import com.backendoori.ootw.user.exception.AlreadyCertifiedUserException;
+import com.backendoori.ootw.user.exception.ExpiredCertificateException;
 import com.backendoori.ootw.user.exception.IncorrectCertificateException;
 import com.backendoori.ootw.user.repository.CertificateRedisRepository;
 import com.backendoori.ootw.user.repository.UserRepository;
@@ -51,7 +52,7 @@ public class CertificateService {
         AssertUtil.throwIf(user.isCertified(), AlreadyCertifiedUserException::new);
 
         Certificate certificate = certificateRedisRepository.findById(certifyDto.email())
-            .orElseThrow(UserNotFoundException::new);
+            .orElseThrow(ExpiredCertificateException::new);
         boolean isIncorrectCertificate = !certifyDto.code().equals(certificate.getCode());
 
         AssertUtil.throwIf(isIncorrectCertificate, IncorrectCertificateException::new);

--- a/src/test/java/com/backendoori/ootw/user/service/CertificateServiceTest.java
+++ b/src/test/java/com/backendoori/ootw/user/service/CertificateServiceTest.java
@@ -10,6 +10,7 @@ import com.backendoori.ootw.user.domain.User;
 import com.backendoori.ootw.user.dto.CertifyDto;
 import com.backendoori.ootw.user.dto.SendCodeDto;
 import com.backendoori.ootw.user.exception.AlreadyCertifiedUserException;
+import com.backendoori.ootw.user.exception.ExpiredCertificateException;
 import com.backendoori.ootw.user.exception.IncorrectCertificateException;
 import com.backendoori.ootw.user.repository.CertificateRedisRepository;
 import com.backendoori.ootw.user.repository.UserRepository;
@@ -173,7 +174,7 @@ class CertificateServiceTest extends MailTest {
             ThrowingCallable certify = () -> certificateService.certify(certifyDto);
 
             // then
-            assertThatExceptionOfType(UserNotFoundException.class)
+            assertThatExceptionOfType(ExpiredCertificateException.class)
                 .isThrownBy(certify);
         }
 


### PR DESCRIPTION
## ✅ 요구사항 
- #72 

## 🚀 주요 변경사항
- [x] 사용자 인증 코드인 Certificate 객체에 대한 TTL 설정
- [x] 만료된 인증 코드에 대한 `Exception` 및 Response 설정

## 💡 기타사항
<!-- ex) 이후에 이런걸 할거고 또한 지금은 이러한 이유 때문에 이런걸 작업했다. 의존성, 추후해야할 일 등등-->
